### PR TITLE
update trigger variables to null on 1st level sent

### DIFF
--- a/functions/src/definitions/common/sendFactCheckerMessages.js
+++ b/functions/src/definitions/common/sendFactCheckerMessages.js
@@ -15,6 +15,24 @@ exports.sendL1CategorisationMessage = async function (
   const voteRequestData = voteRequestSnap.data()
   const responses = await getResponsesObj("factChecker")
   const type = "categorize"
+  try {
+    const updateObj = {}
+    if (voteRequestData.triggerL2Vote !== null) {
+      updateObj.triggerL2Vote = null
+    }
+    if (voteRequestData.triggerL2Others !== null) {
+      updateObj.triggerL2Others = null
+    }
+    if (Object.keys(updateObj).length) {
+      // only perform the update if there's something to update
+      await voteRequestSnap.ref.update(updateObj)
+    }
+  } catch (error) {
+    functions.logger.error(
+      "Error resetting triggerL2Vote or triggerL2Others",
+      error
+    )
+  }
   switch (voteRequestData.platform) {
     case "whatsapp":
       const rows = [


### PR DESCRIPTION
Bug description:

On cases where L2 categorisation/voting was already sent (whatsapp returned 200) previously, but checker did not complete it (could be checker stopped halfway and forgot, or WABA API returned 200 but did not actually send), checkers may eventually re-request the L1 categorisation message (perhaps the reminder message triggers them to). In such cases, because the triggerL2Vote or triggerL2Others variables are already true, they will not receive the L2 vote.

Fix:
Reset the 2 variables to null on the sending of the L1 Categorisation Message

