### PR TITLE
Shifted L2VoteSent and L2OthersSent one lvl up

### DIFF
--- a/functions/src/definitions/checkerHandlers.js
+++ b/functions/src/definitions/checkerHandlers.js
@@ -174,6 +174,24 @@ async function onFactCheckerYes(voteRequestPath, from, platform = "whatsapp") {
     await sendRemainingReminder(from, "whatsapp")
     return
   }
+  try {
+    const updateObj = {}
+    if (voteRequestSnap.get("triggerL2Vote") !== null) {
+      updateObj.triggerL2Vote = null
+    }
+    if (voteRequestSnap.get("triggerL2Others") !== null) {
+      updateObj.triggerL2Others = null
+    }
+    if (Object.keys(updateObj).length) {
+      // only perform the update if there's something to update
+      await voteRequestRef.update(updateObj)
+    }
+  } catch (error) {
+    functions.logger.error(
+      "Error resetting triggerL2Vote or triggerL2Others",
+      error
+    )
+  }
   const messageRef = voteRequestRef.parent.parent
   const messageSnap = await messageRef.get()
   const message = messageSnap.data()

--- a/functions/src/definitions/common/sendFactCheckerMessages.js
+++ b/functions/src/definitions/common/sendFactCheckerMessages.js
@@ -15,24 +15,6 @@ exports.sendL1CategorisationMessage = async function (
   const voteRequestData = voteRequestSnap.data()
   const responses = await getResponsesObj("factChecker")
   const type = "categorize"
-  try {
-    const updateObj = {}
-    if (voteRequestData.triggerL2Vote !== null) {
-      updateObj.triggerL2Vote = null
-    }
-    if (voteRequestData.triggerL2Others !== null) {
-      updateObj.triggerL2Others = null
-    }
-    if (Object.keys(updateObj).length) {
-      // only perform the update if there's something to update
-      await voteRequestSnap.ref.update(updateObj)
-    }
-  } catch (error) {
-    functions.logger.error(
-      "Error resetting triggerL2Vote or triggerL2Others",
-      error
-    )
-  }
   switch (voteRequestData.platform) {
     case "whatsapp":
       const rows = [


### PR DESCRIPTION
Changes:

- Shifted the reset of triggerL2Others and triggerL2Vote up 1 level, from sendL1CategorisationMessage to onFactCheckerYes. Otherwise, it doesn't reset the 2 variables when the message goes through the "info" autocategorisation flow, leading to rare situations where checkers who re-requested the L2VoteMessage to be sent not receiving anything.