### PR TITLE
[Bug] getSignedUrl reading deleted field from messages

### DIFF
--- a/documentation/dataSchema.md
+++ b/documentation/dataSchema.md
@@ -43,7 +43,7 @@ erDiagram
         string hash "Image hash, for image only"
         string mediaId "Media ID from whatsApp, for image only"
         string mimeType "For image only"
-        string storageURL "Cloud storage URL of image, if applicable"
+        string storageUrl "Cloud storage URL of image, if applicable"
         boolean isForwarded "Not used for now"
         boolean isFrequentlyForwarded "Not used for now"
         boolean isReplied "System has replied to the citizen with a final assessment"

--- a/functions/src/definitions/checkerHandlers.js
+++ b/functions/src/definitions/checkerHandlers.js
@@ -194,7 +194,6 @@ async function onFactCheckerYes(voteRequestPath, from, platform = "whatsapp") {
   }
   const messageRef = voteRequestRef.parent.parent
   const messageSnap = await messageRef.get()
-  const message = messageSnap.data()
   const latestInstanceRef = messageSnap.get("latestInstance")
   const latestInstanceSnap = await latestInstanceRef.get()
   const latestType = latestInstanceSnap.get("type") ?? "text"
@@ -208,20 +207,20 @@ async function onFactCheckerYes(voteRequestPath, from, platform = "whatsapp") {
       res = await sendTextMessage(
         "factChecker",
         from,
-        message.text,
+        latestInstanceSnap.get("text"),
         null,
         platform
       )
       updateObj.sentMessageId = res.data.messages[0].id
       break
     case "image":
-      const temporaryUrl = await getSignedUrl(message.storageUrl)
+      const temporaryUrl = await getSignedUrl(latestInstanceSnap.get("storageUrl"))
       if (temporaryUrl) {
         res = await sendImageMessage(
           "factChecker",
           from,
           temporaryUrl,
-          message.caption,
+          latestInstanceSnap.get("caption"),
           null,
           platform
         )
@@ -253,7 +252,7 @@ async function onFactCheckerYes(voteRequestPath, from, platform = "whatsapp") {
       )
       return
   }
-  if (message.machineCategory === "info") {
+  if (messageSnap.get("machineCategory") === "info") {
     // handle case where machine has predicted info, so no need to go into L1 categorisation, but still need to go into L2 voting
     updateObj.triggerL2Vote = true
     updateObj.triggerL2Others = false


### PR DESCRIPTION
Summary:

- Although storageUrl was deleted from messages, getSignedUrl in the onFactCheckerYes logic was still reading from it.

Fix:

- Read storageUrl from latestInstance instead. Other erroneous fields fixed too.