### PR TITLE
feat: add persistence to firebase emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ node_modules/
 .env
 
 local_batch_jobs
+
+# local firebase emulator data
+local-data

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "googleapis": "^105.0.0"
   },
   "scripts": {
-    "lint": "eslint . --ext js,jsx,ts,tsx --fix"
+    "lint": "eslint . --ext js,jsx,ts,tsx --fix",
+    "serve": "firebase emulators:start --import ./local-data --export-on-exit ./local-data"
   }
 }


### PR DESCRIPTION
Sanity check to check functionality:
- Open the firebase emulator firestore tab
- Create new entries
- Ctrl + C, close connection with emulator
- Check that new folder `local-data` in project root has been created
- Start the emulator
- Verify that the data is present

This commit is intended to improve the DX, and remove the constant need to invoke `/mockdb` to populate the emulator with dummy data